### PR TITLE
Remove harmony-collections from build process.

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -11,10 +11,6 @@ _ = require 'underscore-plus'
 
 packageJson = require '../package.json'
 
-# Shim harmony collections in case grunt was invoked without harmony
-# collections enabled
-_.extend(global, require('harmony-collections')) unless global.WeakMap?
-
 module.exports = (grunt) ->
   grunt.loadNpmTasks('grunt-bower-task')
   grunt.loadNpmTasks('grunt-coffeelint')

--- a/build/package.json
+++ b/build/package.json
@@ -24,7 +24,6 @@
     "grunt-lesslint": "0.13.0",
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",
-    "harmony-collections": "~0.3.8",
     "legal-eagle": "~0.4.0",
     "minidump": "~0.8",
     "npm": "~1.4.5",


### PR DESCRIPTION
This was added in https://github.com/atom/atom/commit/b9395d2946032a1a62a8b3d1627917ec854bd226
but doesn't appear to be necessary any longer as this build doesn't
use emissary during the build process.

This was causing a problem for me in my Atom Shell-based application
as I use grunt-typescript and grunt-tslint which die when WeakMap
has been provided by harmony-collections rather than the actual
Harmony support in V8.
