### PR TITLE
Display stdout/stderr from script/run

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -19,7 +19,7 @@
     label: 'Edit'
     submenu: [
       { label: 'Undo', selector: 'undo:', accelerator: 'Command+Z' }
-      { label: 'Redo', selector: 'redo:', accelerator: 'Shift-Command+Z' }
+      { label: 'Redo', selector: 'redo:', accelerator: 'Shift+Command+Z' }
       { type: 'separator' }
       { label: 'Cut', selector: 'cut:', accelerator: 'Command+X' }
       { label: 'Copy', selector: 'copy:', accelerator: 'Command+C' }

--- a/script/run
+++ b/script/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var path = require("path");
-var exec = require("child_process").exec;
+var spawn = require("child_process").spawn;
 require('./utils/config')
 
 var pkgInfo = require(path.resolve(__dirname, '..', 'package.json'));
@@ -26,4 +26,13 @@ if (process.platform === 'win32') {
 
 var toRun = cmd + " " + theArgs.join(" ");
 console.log("Running: " + toRun);
-exec(toRun);
+var child = spawn(cmd, theArgs);
+child.stdout.on('data', function(data) {
+  console.log(data.toString());
+});
+child.stderr.on('data', function(data) {
+  console.error(data.toString());
+});
+child.on('close', function(data) {
+  process.exit(0);
+});

--- a/src/browser/application.coffee
+++ b/src/browser/application.coffee
@@ -26,8 +26,6 @@ class Application
     @window = new AppWindow(options)
     @menu = new AppMenu(pkg: @pkgJson)
 
-    @window.on 'closed', (e) -> app.quit()
-
     @window.show()
 
     @menu.attachToWindow @window

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -47,7 +47,7 @@ parseCommandLine = ->
 
   resourcePath = path.resolve(resourcePath)
 
-  {resourcePath, version, devMode }
+  {resourcePath, version, devMode}
 
 setupCoffeeScript = ->
   CoffeeScript = null


### PR DESCRIPTION
Previously stdout and stderr weren't captured. This switches `script/run` to `child_process.spawn` allowing for streaming stdout and stderr.

This also fixes an error in the 'undo' menu accelerator and fixes up a small code style issue.