### PR TITLE
Enable JavaScript ES6

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "es5": true,
+  "esnext": true
+}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Once you've set that up, do:
 
 Another useful script is `script/grunt`, which will run the local version of Grunt. `script/grunt --help` will tell you the list of available tasks.
 
+### Using JavaScript ES6
+
+JavaScript ES6 / ESNext is available via the 6to5 project for almost all files except for very early in startup. To use it, add `'use 6to5';` to the top of your file. Check out https://6to5.org for more information. 
+
 ### What's the "browser" vs "renderer" code?
 
 Atom Shell has (at least) two separate contexts - when your app first starts up, it is running in a DOM-less node.js loop - there are no windows. This is called the *Browser* context. The built-in code proceeds to start up a `BrowserWindow` object, which then creates a *Rendering* context, which is what you are more used to - it's got the Chrome DevTools and a DOM, yet it can *still* use node.js, as well as several Atom Shell APIs that are made available. Check out the [documentation for Atom Shell](https://github.com/atom/atom-shell/tree/master/docs/api) for more about what you can do.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     }
   ],
   "dependencies": {
+    "6to5-core": "^3.0.14",
     "async": "0.2.6",
     "coffee-script": "1.7.0",
     "coffeestack": "0.7.0",

--- a/src/6to5.coffee
+++ b/src/6to5.coffee
@@ -1,0 +1,160 @@
+###
+Cache for source code transpiled by 6to5.
+
+Inspired by https://github.com/atom/atom/blob/6b963a562f8d495fbebe6abdbafbc7caf705f2c3/src/coffee-cache.coffee.
+###
+
+crypto = require 'crypto'
+fs = require 'fs-plus'
+path = require 'path'
+to5 = require '6to5-core'
+
+stats =
+  hits: 0
+  misses: 0
+
+defaultOptions =
+  # The Chrome dev tools will show the original version of the file
+  # when the source map is inlined.
+  sourceMap: 'inline'
+
+  # Because Atom is currently packaged with a fork of React v0.11,
+  # it makes sense to use the --react-compat option so the React
+  # JSX transformer produces pre-v0.12 code.
+  reactCompat: true
+
+  # Blacklisted features do not get transpiled. Features that are
+  # natively supported in the target environment should be listed
+  # here. Because Atom uses a bleeding edge version of Node/io.js,
+  # I think this can include es6.arrowFunctions, es6.classes, and
+  # possibly others, but I want to be conservative.
+  blacklist: [
+    'useStrict'
+  ]
+
+  # Includes support for es7 features listed at:
+  # http://6to5.org/docs/usage/transformers/#es7-experimental-.
+  experimental: true
+
+  optional: [
+    # Target a version of the regenerator runtime that
+    # supports yield so the transpiled code is cleaner/smaller.
+    'asyncToGenerator'
+    'undefinedToVoid'
+    'undeclaredVariableCheck'
+  ]
+
+###
+shasum - Hash with an update() method.
+value - Must be a value that could be returned by JSON.parse().
+###
+updateDigestForJsonValue = (shasum, value) ->
+  # Implmentation is similar to that of pretty-printing a JSON object, except:
+  # * Strings are not escaped.
+  # * No effort is made to avoid trailing commas.
+  # These shortcuts should not affect the correctness of this function.
+  type = typeof value
+  if type is 'string'
+    shasum.update('"', 'utf8')
+    shasum.update(value, 'utf8')
+    shasum.update('"', 'utf8')
+  else if type in ['boolean', 'number']
+    shasum.update(value.toString(), 'utf8')
+  else if value is null
+    shasum.update('null', 'utf8')
+  else if Array.isArray value
+    shasum.update('[', 'utf8')
+    for item in value
+      updateDigestForJsonValue(shasum, item)
+      shasum.update(',', 'utf8')
+    shasum.update(']', 'utf8')
+  else
+    # value must be an object: be sure to sort the keys.
+    keys = Object.keys value
+    keys.sort()
+
+    shasum.update('{', 'utf8')
+    for key in keys
+      updateDigestForJsonValue(shasum, key)
+      shasum.update(': ', 'utf8')
+      updateDigestForJsonValue(shasum, value[key])
+      shasum.update(',', 'utf8')
+    shasum.update('}', 'utf8')
+
+create6to5VersionAndOptionsDigest = (version, options) ->
+  shasum = crypto.createHash('sha1')
+  # Include the version of 6to5 in the hash.
+  shasum.update('6to5-core', 'utf8')
+  shasum.update('\0', 'utf8')
+  shasum.update(version, 'utf8')
+  shasum.update('\0', 'utf8')
+  updateDigestForJsonValue(shasum, options)
+  shasum.digest('hex')
+
+cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
+jsCacheDir = path.join(
+    cacheDir,
+    create6to5VersionAndOptionsDigest(to5.version, defaultOptions),
+    'js')
+
+getCachePath = (sourceCode) ->
+  digest = crypto.createHash('sha1').update(sourceCode, 'utf8').digest('hex')
+  path.join(jsCacheDir, "#{digest}.js")
+
+getCachedJavaScript = (cachePath) ->
+  if fs.isFileSync(cachePath)
+    try
+      cachedJavaScript = fs.readFileSync(cachePath, 'utf8')
+      stats.hits++
+      return cachedJavaScript
+  null
+
+# Returns the 6to5 options that should be used to transpile filePath.
+createOptions = (filePath) ->
+  options = filename: filePath
+  for key, value of defaultOptions
+    options[key] = value
+  options
+
+# Function that obeys the contract of an entry in the require.extensions map.
+# Returns the transpiled version of the JavaScript code at filePath, which is
+# either generated on the fly or pulled from cache.
+loadFile = (module, filePath) ->
+  sourceCode = fs.readFileSync(filePath, 'utf8')
+  unless sourceCode.startsWith('"use 6to5"') or sourceCode.startsWith("'use 6to5'")
+    module._compile(sourceCode, filePath)
+    return
+
+  cachePath = getCachePath(sourceCode)
+  js = getCachedJavaScript(cachePath)
+
+  unless js
+    options = createOptions filePath
+    try
+      js = to5.transform(sourceCode, options).code
+      stats.misses++
+    catch error
+      console.error('Error compiling %s: %o', filePath, error)
+      throw error
+
+    try
+      fs.writeFileSync(cachePath, js)
+    catch error
+      console.error('Error writing to cache at %s: %o', cachePath, error)
+      throw error
+
+  module._compile(js, filePath)
+
+register = ->
+  Object.defineProperty(require.extensions, '.js', {
+    writable: false
+    value: loadFile
+  })
+
+module.exports =
+  register: register
+  getCacheMisses: -> stats.misses
+  getCacheHits: -> stats.hits
+
+  # Visible for testing.
+  create6to5VersionAndOptionsDigest: create6to5VersionAndOptionsDigest

--- a/src/6to5.coffee
+++ b/src/6to5.coffee
@@ -40,8 +40,6 @@ defaultOptions =
     # Target a version of the regenerator runtime that
     # supports yield so the transpiled code is cleaner/smaller.
     'asyncToGenerator'
-    'undefinedToVoid'
-    'undeclaredVariableCheck'
   ]
 
 ###

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -72,6 +72,7 @@ start = ->
   # to you.
   app.on 'ready', ->
     setupCoffeeScript()
+    require('../6to5').register()
 
     if args.devMode
       require(path.join(args.resourcePath, 'src', 'coffee-cache')).register()

--- a/static/index.js
+++ b/static/index.js
@@ -11,12 +11,14 @@ window.onload = function() {
     // Require before the module cache in dev mode
     if (loadSettings.devMode) {
       require('coffee-script').register();
+      require('../src/6to5').register();
     }
 
     require('vm-compatibility-layer');
 
     if (!loadSettings.devMode) {
       require('coffee-script').register();
+      require('../src/6to5').register();
     }
 
     require('../src/coffee-cache').register();


### PR DESCRIPTION
This PR is copied from atom/atom#5299 (:tophat: to @bolinfest), and enables ES6 JavaScript usage in Atom Shell Starter projects. Just like the Atom PR, you need to have `'use 6to5';` at the top of your file.