### PR TITLE
Bump to atom-shell to 0.21.2 and fix 5to6 initialization

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -163,8 +163,8 @@ module.exports = (grunt) ->
       ]
 
     'build-atom-shell':
-      tag: "6dac8da"
-      nodeVersion: '0.21.0'
+      tag: "v0.21.2"
+      nodeVersion: '0.21.2'
       remoteUrl: "https://github.com/atom/atom-shell"
       buildDir: buildDir
       rebuildPackages: true

--- a/src/6to5.coffee
+++ b/src/6to5.coffee
@@ -119,7 +119,7 @@ createOptions = (filePath) ->
 # either generated on the fly or pulled from cache.
 loadFile = (module, filePath) ->
   sourceCode = fs.readFileSync(filePath, 'utf8')
-  unless sourceCode.startsWith('"use 6to5"') or sourceCode.startsWith("'use 6to5'")
+  unless /^("use 6to5"|'use 6to5')/.test(sourceCode)
     module._compile(sourceCode, filePath)
     return
 


### PR DESCRIPTION
Fixes #38, it seems really odd that Atom has [startsWith]https://github.com/atom/atom/blob/9105348c8c20e6fa77fc400cf5813b34a5db72c8/src/6to5.coffee#L135), I'm not sure what's different about it's environment.

I've fixed the issue by replacing it with a regular expression as suggested, however I'm not confident that there won't be other issues. I also bumped atom-shell to the latest release version however I've noticed that startup time jumped from `500ms` to `~900ms` and that it now beach-balls for several seconds before the app is usable.

@paulcbetts merge when ready.