### PR TITLE
Quit the application when all windows are closed

### DIFF
--- a/src/browser/application.coffee
+++ b/src/browser/application.coffee
@@ -25,6 +25,9 @@ class Application
     @pkgJson = require '../../package.json'
     @windows = []
 
+    app.on 'window-all-closed', ->
+      app.quit() if process.platform in ['win32', 'linux']
+
     @openWithOptions(options)
 
   # Opens a new window based on the options provided.


### PR DESCRIPTION
Closing all windows does not quit the application - 2 processes are left running. Only the _File -> Exit_ menu option properly kills them all. 

This PR fixes it.