### PR TITLE
Precompile ES6 JavaScript on build

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -69,6 +69,13 @@ module.exports = (grunt) ->
 
   installDir = path.resolve(installDir)
 
+  es6to5Config =
+    src: [
+      'src/**/*.js'
+      'static/**/*.js'
+    ]
+    dest: appDir
+
   coffeeConfig =
     glob_to_multiple:
       expand: true
@@ -113,6 +120,8 @@ module.exports = (grunt) ->
     pkg: grunt.file.readJSON('package.json')
 
     coffee: coffeeConfig
+
+    'compile-6to5': es6to5Config
 
     less: lessConfig
 
@@ -194,7 +203,7 @@ module.exports = (grunt) ->
 
   grunt.initConfig(opts)
 
-  grunt.registerTask('compile', ['coffee', 'cson'])
+  grunt.registerTask('compile', ['coffee', 'cson', 'compile-6to5'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-app', 'run-specs'])
 

--- a/build/tasks/compile-es6-task.coffee
+++ b/build/tasks/compile-es6-task.coffee
@@ -1,0 +1,18 @@
+path = require 'path'
+fs = require 'fs'
+{compileFile} = require '../../src/6to5'
+_ = require 'underscore-plus'
+
+module.exports = (grunt) ->
+  {cp} = require('./task-helpers')(grunt)
+
+  grunt.registerTask 'compile-6to5', 'Compile ES6 JS to ES5', ->
+    {src, dest} = grunt.config.get('compile-6to5')
+
+    allFiles = _.map(grunt.file.expand(src), (x) -> path.resolve(x))
+
+    srcRoot = path.resolve('.')
+
+    for file in allFiles
+      js = compileFile(file)
+      fs.writeFileSync(file.replace(srcRoot, dest), js)

--- a/src/6to5.coffee
+++ b/src/6to5.coffee
@@ -29,7 +29,6 @@ defaultOptions =
   # I think this can include es6.arrowFunctions, es6.classes, and
   # possibly others, but I want to be conservative.
   blacklist: [
-    'useStrict'
   ]
 
   # Includes support for es7 features listed at:

--- a/static/index.js
+++ b/static/index.js
@@ -1,3 +1,4 @@
+'use 6to5';
 
 // Warning: You almost certainly do *not* want to edit this code - instead, you
 // want to edit src/renderer/main.coffee instead


### PR DESCRIPTION
This PR precompiles all of the JavaScript marked with ‘use 6to5’ to its non-ES6 version