### PR TITLE
Rename 6to5 to Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Another useful script is `script/grunt`, which will run the local version of Gru
 
 ### Using JavaScript ES6
 
-JavaScript ES6 / ESNext is available via the 6to5 project for almost all files except for very early in startup. To use it, add `'use 6to5';` to the top of your file. Check out https://6to5.org for more information. 
+JavaScript ES6 / ESNext is available via the Babel project for almost all files except for very early in startup. To use it, add `'use babel';` to the top of your file. Check out https://babeljs.io for more information. 
 
 ### What's the "browser" vs "renderer" code?
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "6to5-core": "^3.0.14",
+    "babel-core": "^4.0.2",
     "async": "0.2.6",
     "coffee-script": "1.7.0",
     "coffeestack": "0.7.0",

--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -1,5 +1,5 @@
 ###
-Cache for source code transpiled by 6to5.
+Cache for source code transpiled by babel.
 
 Inspired by https://github.com/atom/atom/blob/6b963a562f8d495fbebe6abdbafbc7caf705f2c3/src/coffee-cache.coffee.
 ###
@@ -7,7 +7,7 @@ Inspired by https://github.com/atom/atom/blob/6b963a562f8d495fbebe6abdbafbc7caf7
 crypto = require 'crypto'
 fs = require 'fs-plus'
 path = require 'path'
-to5 = require '6to5-core'
+babel = require 'babel-core'
 
 stats =
   hits: 0
@@ -33,7 +33,7 @@ defaultOptions =
   ]
 
   # Includes support for es7 features listed at:
-  # http://6to5.org/docs/usage/transformers/#es7-experimental-.
+  # http://babeljs.io/docs/usage/transformers/#es7-experimental-.
   experimental: true
 
   optional: [
@@ -79,10 +79,10 @@ updateDigestForJsonValue = (shasum, value) ->
       shasum.update(',', 'utf8')
     shasum.update('}', 'utf8')
 
-create6to5VersionAndOptionsDigest = (version, options) ->
+createBabelVersionAndOptionsDigest = (version, options) ->
   shasum = crypto.createHash('sha1')
-  # Include the version of 6to5 in the hash.
-  shasum.update('6to5-core', 'utf8')
+  # Include the version of babel in the hash.
+  shasum.update('babel-core', 'utf8')
   shasum.update('\0', 'utf8')
   shasum.update(version, 'utf8')
   shasum.update('\0', 'utf8')
@@ -92,7 +92,7 @@ create6to5VersionAndOptionsDigest = (version, options) ->
 cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
 jsCacheDir = path.join(
     cacheDir,
-    create6to5VersionAndOptionsDigest(to5.version, defaultOptions),
+    createBabelVersionAndOptionsDigest(babel.version, defaultOptions),
     'js')
 
 getCachePath = (sourceCode) ->
@@ -107,7 +107,7 @@ getCachedJavaScript = (cachePath) ->
       return cachedJavaScript
   null
 
-# Returns the 6to5 options that should be used to transpile filePath.
+# Returns the babel options that should be used to transpile filePath.
 createOptions = (filePath) ->
   options = filename: filePath
   for key, value of defaultOptions
@@ -119,7 +119,7 @@ createOptions = (filePath) ->
 # either generated on the fly or pulled from cache.
 loadFile = (module, filePath) ->
   sourceCode = fs.readFileSync(filePath, 'utf8')
-  unless /^("use 6to5"|'use 6to5')/.test(sourceCode)
+  unless /^("use 6to5"|'use 6to5'|"use babel"|'use babel')/.test(sourceCode)
     module._compile(sourceCode, filePath)
     return
 
@@ -129,7 +129,7 @@ loadFile = (module, filePath) ->
   unless js
     options = createOptions filePath
     try
-      js = to5.transform(sourceCode, options).code
+      js = babel.transform(sourceCode, options).code
       stats.misses++
     catch error
       console.error('Error compiling %s: %o', filePath, error)
@@ -155,4 +155,4 @@ module.exports =
   getCacheHits: -> stats.hits
 
   # Visible for testing.
-  create6to5VersionAndOptionsDigest: create6to5VersionAndOptionsDigest
+  createBabelVersionAndOptionsDigest: createBabelVersionAndOptionsDigest

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -94,7 +94,7 @@ start = ->
   # to you.
   app.on 'ready', ->
     setupCoffeeScript()
-    require('../6to5').register()
+    require('../babel').register()
 
     if args.devMode
       require(path.join(args.resourcePath, 'src', 'coffee-cache')).register()

--- a/static/index.js
+++ b/static/index.js
@@ -11,14 +11,14 @@ window.onload = function() {
     // Require before the module cache in dev mode
     if (loadSettings.devMode) {
       require('coffee-script').register();
-      require('../src/6to5').register();
+      require('../src/babel').register();
     }
 
     require('vm-compatibility-layer');
 
     if (!loadSettings.devMode) {
       require('coffee-script').register();
-      require('../src/6to5').register();
+      require('../src/babel').register();
     }
 
     require('../src/coffee-cache').register();


### PR DESCRIPTION
6to5 has been renamed to Babel, more information [here](http://babeljs.io/blog/2015/02/15/not-born-to-die/).