### PR TITLE
fix atom-shell build error since quotes in spawn

### DIFF
--- a/script/build
+++ b/script/build
@@ -8,8 +8,8 @@ process.chdir(path.dirname(__dirname));
 
 cp.safeExec('node script/bootstrap', function() {
   // build/node_modules/.bin/grunt "$@"
-  var gruntPath = '"' + path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd"' : '"');
-  var args = ['--gruntfile', '"' + path.resolve('build', 'Gruntfile.coffee') + '"'];
+  var gruntPath = path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd"' : '');
+  var args = ['--gruntfile', path.resolve('build', 'Gruntfile.coffee')];
   args = args.concat(process.argv.slice(2));
   cp.safeSpawn(gruntPath, args, process.exit);
 });


### PR DESCRIPTION
```
./script/build
Node: v0.10.35
npm: v1.4.28
Installing build modules...
Installing apm...
Installing modules ✓
Deduping modules ✓

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:1011:11)
    at Process.ChildProcess._handle.onexit (child_process.js:802:34)
```

I think it is related #47 , but it is happened in OS X.
I think quoting path caused error in spawn. I introduced in #44 , but I'm not sure it is ok in Windows. 
I don't have Windows environment. So, I can't test it.

After I removed quotes, It's ok to run grunt task.

```
./script/build
Node: v0.10.35
npm: v1.4.28
Installing build modules...
Installing apm...
Installing modules ✓
Deduping modules ✓
Running "build-atom-shell" task
```