### PR TITLE
Fix script test

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -205,7 +205,6 @@ module.exports = (grunt) ->
   ciTasks.push('create-windows-installer') if process.platform is 'win32'
   ciTasks.push('test') if process.platform is 'darwin'
   ciTasks.push('codesign')
-  ciTasks.push('publish-build')
   grunt.registerTask('ci', ciTasks)
 
   defaultTasks = ['build-atom-shell', 'bower:install', 'build', 'set-version']

--- a/build/tasks/dump-symbols-task.coffee
+++ b/build/tasks/dump-symbols-task.coffee
@@ -24,7 +24,8 @@ module.exports = (grunt) ->
   grunt.registerTask 'dump-symbols', 'Dump symbols for native modules', ->
     done = @async()
 
-    symbolsDir = grunt.config.get('atom.symbolsDir')
+    pkgName = grunt.config.get('name')
+    symbolsDir = grunt.config.get("#{pkgName}.symbolsDir")
     rm symbolsDir
     mkdir symbolsDir
 

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -45,4 +45,4 @@ module.exports = (grunt) ->
       console.log results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s")
-      done();
+      done()

--- a/script/test
+++ b/script/test
@@ -6,6 +6,8 @@ require('./utils/config')
 process.chdir(path.dirname(__dirname));
 
 safeExec('node script/bootstrap', function() {
-  var gruntPath = '"' + path.join('node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd"' : '"');
-  safeExec(gruntPath + ' ci --stack --no-color', process.exit);
+  var gruntPath = '"' + path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd"' : '"');
+  var gruntFileOpt = ['--gruntfile', path.resolve('build', 'Gruntfile.coffee')];
+  gruntFileOpt = gruntFileOpt.join(' ');
+  safeExec(gruntPath + ' ci --stack --no-color ' + gruntFileOpt, process.exit);
 });

--- a/spec/hello-spec.coffee
+++ b/spec/hello-spec.coffee
@@ -1,4 +1,4 @@
 describe "Atom shell starter", ->
   describe "Say", ->
     it "hello", ->
-        expect('hello').toBe 'hello'
+      expect('hello').toBe 'hello'

--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -91,9 +91,9 @@ createBabelVersionAndOptionsDigest = (version, options) ->
 
 cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
 jsCacheDir = path.join(
-    cacheDir,
-    createBabelVersionAndOptionsDigest(babel.version, defaultOptions),
-    'js')
+  cacheDir,
+  createBabelVersionAndOptionsDigest(babel.version, defaultOptions),
+  'js')
 
 getCachePath = (sourceCode) ->
   digest = crypto.createHash('sha1').update(sourceCode, 'utf8').digest('hex')


### PR DESCRIPTION
```
./script/test
Node: v0.10.35
npm: v1.4.28
Installing build modules...
Installing apm...
Installing modules ✓
Deduping modules ✓
/bin/sh: node_modules/.bin/grunt: No such file or directory
```

In `script/test`, `--gruntfile` option is absent. So, I added it.
And then in `build/Gruntfile.coffee`, "publish-build" task doesn't exist. So, I removed it.
I don't know what "publish-build" task is for. Please check again it.